### PR TITLE
Use modern nginx SSL/TLS config

### DIFF
--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -13,6 +13,30 @@ server {
   ssl on;
   ssl_certificate /etc/nginx/ssl.crt;
   ssl_certificate_key /etc/nginx/ssl.key;
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:50m;
+  ssl_session_tickets off;
+
+  # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+  ssl_dhparam /path/to/dhparam.pem;
+
+  # modern configuration. tweak to your needs.
+  ssl_protocols TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+  ssl_prefer_server_ciphers on;
+
+  # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+  add_header Strict-Transport-Security max-age=15768000;
+
+  # OCSP Stapling ---
+  # fetch OCSP records from URL in ssl_certificate and cache them
+  ssl_stapling on;
+  ssl_stapling_verify on;
+
+  ## verify chain of trust of OCSP response using Root CA and Intermediate certs
+  ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
+
+  resolver <IP DNS resolver>;
 
   location / {
     proxy_set_header        Host $host;


### PR DESCRIPTION
@jgmize Here's a starting point for a modern config.  I used the generator here (https://mozilla.github.io/server-side-tls/ssl-config-generator/).  It seems there is some missing information that will likely need to be populated before this is ready to land...

1.) Need to generate a dhparam.pem and set the path with ssl_dhparam (stub provided in this PR and reference here (https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html#Forward_Secrecy_&_Diffie_Hellman_Ephemeral_Parameters))
2.) Need to obtain the location of the root CA and intermediate certs and set the path (stub provided in this PR)
3.) Need to set the DNS resolver (I'm not sure what would be preferred in this context)

Hope this helps as a bootstrap for getting "MODERN" with SSL/TLS.

Another good reference: https://wiki.mozilla.org/Security/Server_Side_TLS
