### PR TITLE
Add path-based blacklists

### DIFF
--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -23,53 +23,14 @@ server {
     proxy_pass              http://jenkins;
   }
 
-  # Restrict access to the following paths to localhost (SSH tunneled users)
-  location /api {
+  # Restrict the following paths to localhost (SSH tunneled users only)
+  location ~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob|) {
     deny    all;
     allow   localhost;
   }
 
-  location /restart {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /quietDown {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /user/jenkins {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /jnlpJars {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /script {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /asynchPeople {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /credential-store {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /systemInfo {
-    deny    all;
-    allow   localhost;
-  }
-
-  location /view/All/newJob {
+  # Restrict injectedEnvVars paths to localhost (SSH tunneled users only)
+  location ~* ^.+/injectedEnvVars/$ {
     deny    all;
     allow   localhost;
   }

--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -24,7 +24,7 @@ server {
   }
 
   # Restrict the following paths to localhost (SSH tunneled users only)
-  location ~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob|) {
+  location ~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
     deny    all;
     allow   localhost;
   }

--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -22,4 +22,56 @@ server {
     proxy_redirect http:// https://;
     proxy_pass              http://jenkins;
   }
+
+  # Restrict access to the following paths to localhost (SSH tunneled users)
+  location /api {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /restart {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /quietDown {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /user/jenkins {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /jnlpJars {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /script {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /asynchPeople {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /credential-store {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /systemInfo {
+    deny    all;
+    allow   localhost;
+  }
+
+  location /view/All/newJob {
+    deny    all;
+    allow   localhost;
+  }
+
 }

--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -23,16 +23,14 @@ server {
     proxy_pass              http://jenkins;
   }
 
-  # Restrict the following paths to localhost (SSH tunneled users only)
+  # Restrict access to the following paths
   location ~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
     deny    all;
-    allow   localhost;
   }
 
-  # Restrict injectedEnvVars paths to localhost (SSH tunneled users only)
+  # Restrict access to injectedEnvVars paths
   location ~* ^.+/injectedEnvVars/$ {
     deny    all;
-    allow   localhost;
   }
 
 }


### PR DESCRIPTION
@jgmize this is a stub for how we might restrict access to certain sensitive paths in Jenkins such that they are only accessible on the loopback (or for tunneled users).  If there are paths that you think no one will ever need to visit, like say ./script, we could just make those a solid deny and limit some exposure of admin A from learning admin B's credentials.
