### PR TITLE
Bind blacklist to the webroot

### DIFF
--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -24,7 +24,7 @@ server {
   }
 
   # Restrict access to the following paths
-  location ^~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
+  location ~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
     deny    all;
   }
 

--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -24,7 +24,7 @@ server {
   }
 
   # Restrict access to the following paths
-  location ~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
+  location ^~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
     deny    all;
   }
 

--- a/templates/nginx-cfg.j2
+++ b/templates/nginx-cfg.j2
@@ -24,7 +24,7 @@ server {
   }
 
   # Restrict access to the following paths
-  location ~ /(restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
+  location ^~ /(api|restart|quietDown|user/jenkins|jnlpJars|script|asynchPeople|credential-store|systemInfo|view/All/newJob) {
     deny    all;
   }
 


### PR DESCRIPTION
Prevent the recently added white-list from matching anything but the root directory
