### PR TITLE
 Enable Jenkins-CI Permissive Script Plugin. 

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -207,6 +207,17 @@
         regexp=^JENKINS_ARGS=
         line='JENKINS_ARGS="--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --httpListenAddress=127.0.0.1"'
       notify: Restart Jenkins
+      tags:
+        - jenkins-conf
+
+    - name: Enable Jenkins-CI Permissive Script Plugin
+      lineinfile:
+        dest=/etc/default/jenkins
+        regexp=^JAVA_ARGS=
+        line='JAVA_ARGS="-Djava.awt.headless=true -Dpermissive-script-security.enabled=true"'
+      notify: Restart Jenkins
+      tags:
+        - jenkins-conf
 
     - name: Set Jenkins-CI gitconfig
       template:
@@ -221,8 +232,6 @@
 
     - name: Start nginx
       service: name=nginx state=started
-      tags:
-        - install-plugins
 
     - name: Copy docker-cleanup script
       template:


### PR DESCRIPTION
This should permanently enable the permissive script plugin and survive jenkins upgrades.